### PR TITLE
Make get.sh generic for cross repo sharing

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -1,30 +1,36 @@
 #!/bin/bash
 
 # Copyright OpenFaaS Author(s) 2019
-version=$(curl -sI https://github.com/openfaas/faas-cli/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+#########################
+# Repo specific content #
+#########################
+
+export VERIFY_CHECKSUM=1
+export ALIAS_NAME="faas"
+export OWNER="openfaas"
+export REPO="faas-cli"
+export SUCCESS_CMD="$REPO version"
+export BINLOCATION="/usr/local/bin"
+
+###############################
+# Content common across repos #
+###############################
+
+version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 if [ ! $version ]; then
-    echo "Failed while attempting to install faas-cli. Please manually install:"
+    echo "Failed while attempting to install $REPO. Please manually install:"
     echo ""
-    echo "1. Open your web browser and go to https://github.com/openfaas/faas-cli/releases"
-    echo "2. Download the latest release for your platform. Call it 'faas-cli'."
-    echo "3. chmod +x ./faas-cli"
-    echo "4. mv ./faas-cli /usr/local/bin"
-    echo "5. ln -sf /usr/local/bin/faas-cli /usr/local/bin/faas"
+    echo "1. Open your web browser and go to https://github.com/$OWNER/$REPO/releases"
+    echo "2. Download the latest release for your platform. Call it '$REPO'."
+    echo "3. chmod +x ./$REPO"
+    echo "4. mv ./$REPO $BINLOCATION"
+    if [ -n "$ALIAS_NAME" ]; then
+        echo "5. ln -sf $BINLOCATION/$REPO /usr/local/bin/$ALIAS_NAME"
+    fi
     exit 1
 fi
 
 hasCli() {
- 
-    has=$(which faas-cli)
-
-    if [ "$?" = "0" ]; then
-        echo
-        echo "You already have the faas-cli!"
-        export n=1
-        echo "Overwriting in $n seconds.. Press Control+C to cancel."
-        echo
-        sleep $n
-    fi
 
     hasCurl=$(which curl)
     if [ "$?" = "1" ]; then
@@ -32,7 +38,6 @@ hasCli() {
         exit 1
     fi
 }
-
 
 checkHash(){
 
@@ -52,7 +57,7 @@ checkHash(){
             rm $targetFile
             echo "Binary checksum didn't match. Exiting"
             exit 1
-        fi
+        fi   
     fi
 }
 
@@ -64,6 +69,12 @@ getPackage() {
     case $uname in
     "Darwin")
     suffix="-darwin"
+    ;;
+    "MINGW"*)
+    suffix=".exe"
+    BINLOCATION="$HOME/bin"
+    mkdir -p $BINLOCATION
+
     ;;
     "Linux")
         arch=$(uname -m)
@@ -81,62 +92,84 @@ getPackage() {
     ;;
     esac
 
-    targetFile="/tmp/faas-cli$suffix"
+    targetFile="/tmp/$REPO$suffix"
     
     if [ "$userid" != "0" ]; then
-        targetFile="$(pwd)/faas-cli$suffix"
+        targetFile="$(pwd)/$REPO$suffix"
     fi
 
     if [ -e $targetFile ]; then
         rm $targetFile
     fi
 
-    url=https://github.com/openfaas/faas-cli/releases/download/$version/faas-cli$suffix
+    url=https://github.com/$OWNER/$REPO/releases/download/$version/$REPO$suffix
     echo "Downloading package $url as $targetFile"
 
     curl -sSL $url --output $targetFile
 
     if [ "$?" = "0" ]; then
 
-    checkHash
+        if [ "$VERIFY_CHECKSUM" = "1" ]; then
+            checkHash
+        fi
 
     chmod +x $targetFile
 
     echo "Download complete."
        
-        if [ "$userid" != "0" ]; then
+    if [ ! -w "$BINLOCATION" ]; then
+
+            echo
+            echo "============================================================"
+            echo "  The script was run as a user who is unable to write"
+            echo "  to $BINLOCATION. To complete the installation the"
+            echo "  following commands may need to be run manually."
+            echo "============================================================"
+            echo
+            echo "  sudo cp $REPO$suffix $BINLOCATION/$REPO"
             
-            echo
-            echo "=========================================================" 
-            echo "==    As the script was run as a non-root user the     =="
-            echo "==    following commands may need to be run manually   =="
-            echo "========================================================="
-            echo
-            echo "  sudo cp faas-cli$suffix /usr/local/bin/faas-cli"
-            echo "  sudo ln -sf /usr/local/bin/faas-cli /usr/local/bin/faas"
+            if [ -n "$ALIAS_NAME" ]; then
+                echo "  sudo ln -sf $BINLOCATION/$REPO $BINLOCATION/$ALIAS_NAME"
+            fi
+            
             echo
 
         else
 
             echo
-            echo "Running as root - Attempting to move faas-cli to /usr/local/bin"
+            echo "Running with sufficient permissions to attempt to move $REPO to $BINLOCATION"
 
-            mv $targetFile /usr/local/bin/faas-cli
+            if [ ! -w "$BINLOCATION/$REPO" ] && [ -f "$BINLOCATION/$REPO" ]; then
+
+            echo
+            echo "================================================================"
+            echo "  $BINLOCATION/$REPO already exists and is not writeable"
+            echo "  by the current user.  Please adjust the binary ownership"
+            echo "  or run sh/bash with sudo." 
+            echo "================================================================"
+            echo
+            exit 1
+
+            fi
+
+            mv $targetFile $BINLOCATION/$REPO
         
             if [ "$?" = "0" ]; then
-                echo "New version of faas-cli installed to /usr/local/bin"
+                echo "New version of $REPO installed to $BINLOCATION"
             fi
 
             if [ -e $targetFile ]; then
                 rm $targetFile
             fi
 
-            if [ ! -L /usr/local/bin/faas ]; then
-	            ln -s /usr/local/bin/faas-cli /usr/local/bin/faas
-	            echo "Creating alias 'faas' for 'faas-cli'."
-    	    fi
+            if [ -n "$ALIAS_NAME" ]; then
+                if [ ! -L $BINLOCATION/$ALIAS_NAME ]; then
+                    ln -s $BINLOCATION/$REPO $BINLOCATION/$ALIAS_NAME
+                    echo "Creating alias '$ALIAS_NAME' for '$REPO'."
+                fi
+            fi
 
-            faas-cli version
+            ${SUCCESS_CMD}
         fi
     fi
 }


### PR DESCRIPTION
Currently the get.sh scripts across a number of repos are roughly based off the faas-cli filewith bespoke changes made depending upon the needs of the respective projects.

This change make the faas-cli script generic enough so that the common content can be used across all the repos without any changes.  The only changes required to tailor the file's operation to the respective repo are to be made in the Repo specific content section.

Also adds a check for a git bash signature to enable downloading of the .exe variant when running on git bash on Windows.

Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Testing

### Clean install
```sh
$ ls -la /usr/local/bin | grep faas
$ curl -SsL https://5db9f821c22f3400081b8898--fervent-joliot-2016a6.netlify.com/ | sh
Downloading package https://github.com/openfaas/faas-cli/releases/download/0.9.5/faas-cli-dar
win as /Users/rgee0/go/src/github.com/openfaas/cli.openfaas.com/faas-cli-darwin
Download complete.

Running with sufficient permissions to attempt to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
Creating alias 'faas' for 'faas-cli'.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  b7a67fe8d6a02aef35caae615ba56333e7337bfe
 version: 0.9.5

Gateway
 uri:     http://127.0.0.1:8080
 version: 0.12.0
 sha:     ebc41933b7115e100b0a63137de43bd6abe34293
 commit:  Remove prometheus changes


Provider
 name:          faas-swarm
 orchestration: swarm
 version:       0.6.1 
 sha:           3cac0ccc2e8bb7f567739a33f7d414cdb58440aa

$ ls -la /usr/local/bin | grep faas
lrwxr-xr-x    1 rgee0       staff        23 30 Oct 21:01 faas -> /usr/local/bin/faas-cli
-rwxr-xr-x    1 rgee0       staff   9147320 30 Oct 21:03 faas-cli
```

### Update existing
```sh
$ curl -SsL https://5db9f821c22f3400081b8898--fervent-joliot-2016a6.netlify.com/ | sh
Downloading package https://github.com/openfaas/faas-cli/releases/download/0.9.5/faas-cli-darwin as /Users/rgee0/go/src/github.com/openfaas/cli.openfaas.com/faas-cli-darwin
Download complete.

Running with sufficient permissions to attempt to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  b7a67fe8d6a02aef35caae615ba56333e7337bfe
 version: 0.9.5

Gateway
 uri:     http://127.0.0.1:8080
 version: 0.12.0
 sha:     ebc41933b7115e100b0a63137de43bd6abe34293
 commit:  Remove prometheus changes


Provider
 name:          faas-swarm
 orchestration: swarm
 version:       0.6.1 
 sha:           3cac0ccc2e8bb7f567739a33f7d414cdb58440aa

$ ls -la /usr/local/bin | grep faas
lrwxr-xr-x    1 rgee0       staff        23 30 Oct 21:01 faas -> /usr/local/bin/faas-cli
-rwxr-xr-x    1 rgee0       staff   9147320 30 Oct 21:05 faas-cli
```

### Portability test
Change the repo specific section to reflect setting for inlets.  Dont verify the checksum and do not create an alias:
```sh
export VERIFY_CHECKSUM=0
export ALIAS=""
export OWNER=inlets
export REPO=inlets
```
The existing inlets binary is owned by root so run with sudo:
```sh
$ ls -la /usr/local/bin/ | grep inlets
-rwxr-xr-x    1 root        wheel  12608128 30 Oct 21:10 inlets
$ sudo ./get.sh
Downloading package https://github.com/inlets/inlets/releases/download/2.6.1/inlets-darwin as /tmp/inlets-darwin
Download complete.

Running with sufficient permissions to attempt to move inlets to /usr/local/bin
New version of inlets installed to /usr/local/bin
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.6.1
Git Commit: 5a1abcf24dcd30dc4a251902aa6cc7cb981ef0ae
```
### Change the ownership and run without sudo
```sh
$ sudo chown rgee0:staff /usr/local/bin/inlets 
$ ls -la /usr/local/bin/ | grep inlets
-rwxr-xr-x    1 rgee0       staff  12608128 30 Oct 21:11 inlets
$ ./get.sh
Downloading package https://github.com/inlets/inlets/releases/download/2.6.1/inlets-darwin as /Users/rgee0/go/src/github.com/openfaas/cli.openfaas.com/inlets-darwin
Download complete.

Running with sufficient permissions to attempt to move inlets to /usr/local/bin
New version of inlets installed to /usr/local/bin
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.6.1
Git Commit: 5a1abcf24dcd30dc4a251902aa6cc7cb981ef0ae
```