### PR TITLE
Fix download script

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -19,7 +19,7 @@ export BINLOCATION="/usr/local/bin"
 version=""
 
 echo "Finding latest version from GitHub"
-version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i "location:" | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 echo $version
 
 if [ ! $version ]; then


### PR DESCRIPTION
## Description

Fix download script

## Motivation

The download script was failing due to the way grep became
non-deterministic because of new headers returned in the
version check against GitHub's server.

Related: https://github.com/openfaas/cli.openfaas.com/pull/5

## Testing

Tested locally with "sh get.sh", which worked as expected.

This PR should be more targeted than #5 - but credit goes to
@mikeguz for raising it.

## Anything else we should know?

OpenFaaS provides support for commercial users, and a sponsorship option for those who are happy managing things themselves.

Things go wrong from time to time, it makes business sense to have us on the hook to fix it for you, rather than relying on our goodwill. The same goes for maintenance.

https://www.openfaas.com/support

https://github.com/sponsors/openfaas/

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>