### PR TITLE
Use explicit path for SUCCESS_CMD

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -9,8 +9,8 @@ export VERIFY_CHECKSUM=1
 export ALIAS_NAME="faas"
 export OWNER="openfaas"
 export REPO="faas-cli"
-export SUCCESS_CMD="$REPO version"
 export BINLOCATION="/usr/local/bin"
+export SUCCESS_CMD="$BINLOCATION/$REPO version"
 
 ###############################
 # Content common across repos #
@@ -30,7 +30,7 @@ if [ ! $version ]; then
     echo "3. chmod +x ./$REPO"
     echo "4. mv ./$REPO $BINLOCATION"
     if [ -n "$ALIAS_NAME" ]; then
-        echo "5. ln -sf $BINLOCATION/$REPO /usr/local/bin/$ALIAS_NAME"
+        echo "5. ln -sf $BINLOCATION/$REPO $BINLOCATION/$ALIAS_NAME"
     fi
     exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This propagates a change that was initially made in arkade
(https://github.com/alexellis/arkade/pull/685) after it was found
that sudo on CentOS9 was not able to find the new binary in the path
it uses by default. This led to a poor UX as the binary had been
installed but an error in running SUCCESS_CMD gave the impression
that the installation had failed. This change adds an explicit
path to SUCCESS_CMD so that it can be found when running through sudo
with a 'secure_path' set.

Also propagate change made in (https://github.com/alexellis/k3sup/pull/379):
> Address a future bug where ALIAS_NAME is set. $BINLOCATION was
> only used once in the ln command which would lead to a future failure
> where ALIAS_NAME is set and the BINLOCATION was not /usr/local/bin.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Relates to https://github.com/alexellis/arkade/issues/683 and https://github.com/alexellis/arkade/pull/685 and specifically https://github.com/alexellis/arkade/issues/685#issuecomment-1118269855_

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on CentOS9
Current script exits with non-zero exit code: `main: line 176: faas-cli: command not found`

Using changed script on my fork:
```
# curl -sLS https://raw.githubusercontent.com/welteki/cli.openfaas.com/fix-getsh/get.sh | sudo sh

Finding latest version from GitHub
0.14.2
Downloading package https://github.com/openfaas/faas-cli/releases/download/0.14.2/faas-cli as /tmp/faas-cli
Download complete.

Running with sufficient permissions to attempt to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  b1c09c0243f69990b6c81a17d7337f0fd23e7542
 version: 0.14.2
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
